### PR TITLE
Fix the setup script

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -7,8 +7,8 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 echo "making data folder structure"
-mkdir data data/data data/logs
-chown -R 8983 data 
+mkdir db/solr/data db/solr/data/data db/solr/data/logs
+chown -R 8983 db/solr/data
 
 
 echo "done :)"


### PR DESCRIPTION
Since the move from `data/` to `db/solr/data` the setup script didn't properly create the required folders for solr.